### PR TITLE
Make MilkProduction attributes optional - see HEA-98

### DIFF
--- a/apps/baseline/migrations/0001_initial.py
+++ b/apps/baseline/migrations/0001_initial.py
@@ -652,11 +652,15 @@ class Migration(migrations.Migration):
                 ("milking_animals", models.PositiveSmallIntegerField(verbose_name="Number of milking animals")),
                 (
                     "lactation_days",
-                    models.PositiveSmallIntegerField(verbose_name="Average number of days of lactation"),
+                    models.PositiveSmallIntegerField(
+                        blank=True, null=True, verbose_name="Average number of days of lactation"
+                    ),
                 ),
                 (
                     "daily_production",
-                    models.PositiveSmallIntegerField(verbose_name="Average daily milk production per animal"),
+                    models.PositiveSmallIntegerField(
+                        blank=True, null=True, verbose_name="Average daily milk production per animal"
+                    ),
                 ),
                 (
                     "quantity_butter_production",

--- a/apps/baseline/models.py
+++ b/apps/baseline/models.py
@@ -1169,8 +1169,12 @@ class MilkProduction(LivelihoodActivity):
 
     # Production calculation /validation is `lactation days * daily_production`
     milking_animals = models.PositiveSmallIntegerField(verbose_name=_("Number of milking animals"))
-    lactation_days = models.PositiveSmallIntegerField(verbose_name=_("Average number of days of lactation"))
-    daily_production = models.PositiveSmallIntegerField(verbose_name=_("Average daily milk production per animal"))
+    lactation_days = models.PositiveSmallIntegerField(
+        blank=True, null=True, verbose_name=_("Average number of days of lactation")
+    )
+    daily_production = models.PositiveSmallIntegerField(
+        blank=True, null=True, verbose_name=_("Average daily milk production per animal")
+    )
 
     # @TODO see https://fewsnet.atlassian.net/browse/HEA-65
     # This is currently not required for scenario development and is only used for the kcal calculations in the BSS.
@@ -1214,6 +1218,13 @@ class MilkProduction(LivelihoodActivity):
     def validate_quantity_produced(self):
         # @TODO Add validation
         pass
+
+    def clean(self):
+        super().clean()
+        if self.milking_animals and not self.lactation_days:
+            raise ValidationError(_("Lactation days must be provided if there are milking animals"))
+        if self.milking_animals and not self.daily_production:
+            raise ValidationError(_("Daily production must be provided if there are milking animals"))
 
     class Meta:
         verbose_name = LivelihoodStrategyType.MILK_PRODUCTION.label


### PR DESCRIPTION
Some BSS record that the Wealth Group had 0 milking animals. In this case the `milking_animals` contains 0 but the `lactation_days` and `daily_production` are blank. Therefore, these fields need to be `null=True`.

I have added validation to `MilkProduction.clean()` to check that the attributes have values if `milking_animals` has a value.