### PR TITLE
Switch from OSMGeoAdmin to GISModelAdmin for Django 5.x - see HEA-163

### DIFF
--- a/apps/baseline/admin.py
+++ b/apps/baseline/admin.py
@@ -1,8 +1,8 @@
 from copy import deepcopy
 
 from django.contrib import admin
+from django.contrib.gis.admin import GISModelAdmin
 
-from common.admin import GeoModelAdmin
 from common.fields import translation_fields
 from metadata.models import LivelihoodStrategyType
 
@@ -80,7 +80,7 @@ class LivelihoodZoneAdmin(admin.ModelAdmin):
     list_filter = ("country",)
 
 
-class LivelihoodZoneBaselineAdmin(GeoModelAdmin):
+class LivelihoodZoneBaselineAdmin(GISModelAdmin):
     fieldsets = [
         (
             None,
@@ -134,7 +134,7 @@ class LivelihoodZoneBaselineAdmin(GeoModelAdmin):
     date_hierarchy = "reference_year_start_date"
 
 
-class CommunityAdmin(GeoModelAdmin):
+class CommunityAdmin(GISModelAdmin):
     fields = (
         "name",
         "full_name",

--- a/apps/common/admin.py
+++ b/apps/common/admin.py
@@ -1,7 +1,6 @@
 # Register your models here.
 from django.contrib import admin
 from django.contrib.admin.options import InlineModelAdmin
-from django.contrib.gis.admin import OSMGeoAdmin
 from treebeard.admin import TreeAdmin
 from treebeard.forms import movenodeform_factory
 
@@ -87,17 +86,6 @@ class UnitOfMeasureAdmin(admin.ModelAdmin):
     )
     list_filter = ("unit_type",)
     inlines = [UnitOfMeasureConversionInline]
-
-
-class GeoModelAdmin(OSMGeoAdmin, admin.ModelAdmin):
-    """
-    Enhanced OSMGeoAdmin class that:
-    * Uses https connections to the CDN for OpenLayers JavaScript if the original
-      page was requested using https
-
-    """
-
-    openlayers_url = "https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.11/OpenLayers.js"
 
 
 admin.site.register(Currency, CurrencyAdmin)


### PR DESCRIPTION
@girumb this is just a small change I know will be needed for HEA-163. It is not the full ticket.